### PR TITLE
add http protocol to host if user did not enter it

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -11,7 +11,17 @@ $(document).ready(function() {
 
     $(".url-to-load").on("keyup", function (e) {
         if (e.keyCode === 13) {
-            $("iframe").attr("src", $(this).val());
+            var url = $(this).val().replace(/^\W+/, "");
+
+            /*
+             * Append protocol to domain if it wasn't provided
+             * Use HTTP protocol by default. It will switch to HTTPS if web server will redirect to it
+             */
+            if (!url.match(/^http/i)) {
+                url = "http://" + url;
+            }
+
+            $("iframe").attr("src", url);
         }
     });
 });


### PR DESCRIPTION
If user did not enter the protocol in the field, the `iframe` source will become a simple string and will start to seach the file with host name on server.

For example:
- Type `getbootstrap.com`
- Browser throw error that file `getbootstrap.com` is not on server(in root directory of `IsRespo`)
- `iframe` element is not loaded or shows an error 'smile' :ghost: 
